### PR TITLE
bash: Remove unnecessary `;` in if statements

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -29,14 +29,14 @@ echo "${name}"
 ### If
 
 ```sh
-if [ conditional-expression ];  
+if [ conditional-expression ]  
 then  
 statements  
 fi  
 ```
 ### If-else
 ```sh
-if [ conditional-expression ];  
+if [ conditional-expression ]  
 then  
    statements  
 else  
@@ -45,10 +45,10 @@ fi
 ```
 ### Else-If
 ```sh
-if [ conditional-expression ];  
+if [ conditional-expression ]  
 then  
    statements  
-elif [ conditional-expression ];  
+elif [ conditional-expression ]  
 then  
  statements  
 else  


### PR DESCRIPTION
trailing `;` is only required when writing a oneliner if statement with a body in the same line.